### PR TITLE
Reference Update

### DIFF
--- a/content/02.introduction.md
+++ b/content/02.introduction.md
@@ -13,7 +13,7 @@ As the volume of data exploded, methods for statistical analysis transitioned us
 
 Two strategies of mass spectrometry-based proteomics differ fundamentally by whether proteins are cleaved into peptides before analysis: "top-down" and "bottom-up". 
 Bottom-up proteomics (also refered to as shotgun proteomics) is defined by the hydrolysis of proteins into peptide pieces [@DOI:10.1038/nature19949]. 
-Therefore, bottom-up proteomics does not actually measure proteins, but must infer their presence [@URL:https://doi.org/10.1021/ac0341261]. 
+Therefore, bottom-up proteomics does not actually measure proteins, but must infer their presence [@DOI:10.1021/ac0341261]. 
 Sometimes proteins are infered from only one peptide sequence representing a small fraction of the total protein sequence predicted from the genome. 
 In contrast, top-down proteomics attempts to measure all proteins intact [@DOI:10.1039/C9MO00154A]. 
 The potential benefit of top-down proteomics is the ability to measure proteoforms [@DOI:10.1126/science.aat1884]. 


### PR DESCRIPTION
In the HTML and PDF version of the introduction, it looked like reference 5 and 8 were different papers. However, they are the same. This was probably caused by different formatting (URL vs. DOI) of the references in this file.