### PR TITLE
Add references and more explanation to contaminants section

### DIFF
--- a/content/13.databases.md
+++ b/content/13.databases.md
@@ -156,6 +156,11 @@ In these cases, defaulting to the minimum requirements of listing number of entr
 Samples are rarely comprised of only proteins from the species of interest. 
 There can be protein contamination during sample collection or processing. 
 This may include proteins from human skin, wool from clothing, particles from latex, or even porcine trypsin itself, all of which contain proteins that can be digested along with the intended sample and analyzed in the mass spectrometer. 
+Avoiding unwanted matching of mass spectra originating from contaminant proteins to the cellular proteins due to sequence similarities is important to the identification and quantitation of as many cellular proteins as possible.
+To avoid random matching, repositories of supplementary sequences for contaminant proteins have been added to a reference database for MS data searches.
+Appending a contaminants database to the reference database allows the identification of peptides that are not exclusive to one species.
+Peptides that are exclusive to the organism of interest are used to calculate abundance to avoid inflated quantitative results due to potential contaminant peptides.
+
 As early as 2004, The Global Proteome Machine was providing a protein sequence collection of these common Repository of Adventitious Proteins (cRAP), while another contaminant list was published in 2008 [@PMID:18790129]. 
 The current cRAP version (v1.0) was described in 2012 [@URL:https://www.thegpm.org/crap] and is still widely in use today. 
 cRAP is the contaminant protein list used in nearly all modern database searching software, though the documentation, versioning or updating of many of these “built-in” contaminant sequence collections is difficult to follow. 
@@ -165,8 +170,12 @@ This list of known frequently contaminating proteins can either be automatically
 Recently the Hao Lab has revisited these common contaminant sequences in an effort to update the protein sequences, test their utility on experimental data, and add or remove entries [@DOI:10.1101/2022.04.27.489766]. 
 
 In addition to these environmentally unintended contaminants, there are known contaminants that also have available protein sequence collections (or can be generated using the steps above) and should be included in the search space. 
-These can include the media cells were grown in (e.g., fetal bovine serum), food fed to cells/animals (e.g., Caenorhabditis elegans grown on Escherichia coli) or known non-specific binders in affinity purification (i.e., CRAPome [@PMID:23921808]). 
+These can include the media cells were grown in (e.g., fetal bovine serum [@PMID:20641139; @PMID:33532042], food fed to cells/animals (e.g., Caenorhabditis elegans grown on Escherichia coli) or known non-specific binders in affinity purification (i.e., CRAPome [@PMID:23921808]). 
+The common Repository of Fetal Bovine Serum Proteins (cRFP)[@PMID:31475827] are protein lists of common protein contaminants and fetal serum bovine sequences used to reduced the number of falsely identified proteins in cell culture experiments.
+Cells washed or cultured in contaminant free media before harvest or the collection of secreted proteins depletes most high abundance contaminant proteins but the sequence similarity between contaminant and secreted proteins can cause false identifications and overestimation of the true protein abundance leading to wasted resources and time on validating false leads.
 As emphasized throughout this section, accurately defining the search space is essential for accurate results and, especially in the case of contaminants, requires knowledge of the experiment and sample processing to adequately define possible background proteins.
+
+
 
 ### Choosing the right database
 


### PR DESCRIPTION
Flushed out the contaminants database section with more background regarding the effect of contaminants on false protein identification and quantitation. Also added in a few more contaminant databases for cell culture experiments with fetal bovine serum.

Please provide a description of your changes:

Please check the following about your suggested changed:
- [ ] The new text has one sentence per line
- [ ] preprints that are cited are listed as an issue for discussion and peer review
